### PR TITLE
Allow for non-inheritance usage

### DIFF
--- a/enumeratum-slick/src/main/scala/enumeratum/SlickEnum.scala
+++ b/enumeratum-slick/src/main/scala/enumeratum/SlickEnum.scala
@@ -1,0 +1,38 @@
+package enumeratum
+
+import slick.jdbc.{PositionedParameters, SetParameter}
+
+import scala.reflect.ClassTag
+
+/**
+  * Provides helpers for building Slick typeclass instances for an [[Enum]]
+  *
+  * Can also be used via the companion object
+  */
+trait SlickEnum {
+
+  def buildSetParameterTypeForEnum[E <: EnumEntry](
+      nameFn: String => String = identity): SetParameter[E] = {
+    new SetParameter[E] {
+      def apply(e: E, pp: PositionedParameters): Unit = {
+        val transformedName = nameFn(e.entryName)
+        pp.setString(transformedName)
+      }
+    }
+  }
+
+  def buildMappedColumnTypeForEnum[E <: EnumEntry, S](enum: Enum[E],
+                                                      eToString: E => S,
+                                                      stringToE: S => E,
+                                                      profile: slick.profile.RelationalProfile)(
+      implicit tag: ClassTag[E],
+      sMapper: profile.BaseColumnType[S]): profile.BaseColumnType[E] = {
+    profile.MappedColumnType.base[E, S](
+      { eToString(_) },
+      { stringToE }
+    )
+  }
+
+}
+
+object SlickEnum extends SlickEnum

--- a/enumeratum-slick/src/main/scala/enumeratum/SlickEnumSupport.scala
+++ b/enumeratum-slick/src/main/scala/enumeratum/SlickEnumSupport.scala
@@ -2,7 +2,7 @@ package enumeratum
 
 import scala.reflect.ClassTag
 
-import slick.jdbc.{PositionedParameters, SetParameter}
+import slick.jdbc.SetParameter
 
 /**
   * When mixed in, allows creation of Slick mapped column types for enumeratum.Enum instances


### PR DESCRIPTION
Working PoC that relates to https://github.com/lloydmeta/enumeratum/pull/187

* Extract typeclass-building methods into a trait, SlickEnum that can be
  used via inheritance or via its companion object
  * Instead of taking an abstract val profile, simply takes profile as a param
    and returns a type-dependent profile.BaseColumnType
* Have SlickEnumSupport extend this trait and offer additional sugar based on it